### PR TITLE
feat: open guild book in new tab

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -141,6 +141,8 @@ const Navbar = () => {
             <Link 
               href="https://dfares.notion.site/DFArchon-One-Pager-TBD-1a7a4dc234338049903fc2568e5ec4fc" 
               className="text-white py-2 px-4 rounded hover:bg-primary/20"
+              target="_blank"
+              rel="noopener noreferrer"
               onClick={() => setIsMobileMenuOpen(false)}
             >
               GuildBook


### PR DESCRIPTION
I would suggest opening the guildbook in a new page/tab, since we are actually navigating out from dfmud.xyz, seemed unatural to me when i opened the guild page.