### PR TITLE
fix: metadataBase url

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+const isDevMode = process.env['NODE_ENV'] === 'development';
+const siteUrl = 'https://dfmud.xyz';
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -13,6 +16,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  // set metadataBase url when we are not development mode
+  // @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase
+  metadataBase: !isDevMode ? new URL(siteUrl) : undefined,
   title: "Dark Forest Mud — A Decentralized Journey to Conquer the Cosmos",
   description: "A real‑time strategy game built on EVM using zkSNARKs technology. Explore an infinite procedurally generated universe.",
   keywords: ["Dark Forest", "Ethereum", "zkSNARKs", "Web3 Game", "Blockchain Game", "Strategy Game"],
@@ -24,7 +30,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Dark Forest Mud — A Decentralized Journey to Conquer the Cosmos",
     description: "A real‑time strategy game built on EVM using zkSNARKs technology",
-    url: "https://darkforest.mud",
+    url: siteUrl,
     siteName: "Dark Forest Mud",
     images: [
       {


### PR DESCRIPTION
Since the urls for icons and images are currently set with an relative path they are therefore prefixed with `http://localhost:3000` when building the site.

This PR fixes that so we actually use the site url https://dfmud.xyz see next metadatabase docs [here]( https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase)

## Before
![Skjermbilde 2025-04-04 kl  22 34 24](https://github.com/user-attachments/assets/e41ac094-19c2-48ad-bebc-a1c1ae9a5f98)

## After
![Skjermbilde 2025-04-04 kl  22 35 49](https://github.com/user-attachments/assets/ee5e2687-5138-4024-8013-32aaa4815f9c)
